### PR TITLE
Adds weeklySetblock property to TeamMembers

### DIFF
--- a/api/handlers/airtable.js
+++ b/api/handlers/airtable.js
@@ -35,6 +35,34 @@ const airtable = module.exports = (function () {
         });
     };
 
+    const fetchFilteredRecords = (params) => {
+        return new Promise((resolve, reject) => {
+            let baseRecords = []
+            
+            base(params.tableName)
+            .select({
+                filterByFormula: params.filterFormula,
+                maxRecords: params.maxRecords || 20,
+                sort: params.sort || [{ field: 'Date', direction: 'asc' }],
+                view: params.viewName,
+            })
+            .eachPage((records, fetchNextPage) => {
+                records.forEach((record) => {
+                    baseRecords.push(record)
+                });
+
+                fetchNextPage();
+            }, function done(err) {
+                if (err) {
+                    console.error(err);
+                    reject(err);
+                } else {
+                    resolve(baseRecords)
+                }
+            });
+        });
+    };
+
     const fetchTableRecord = (params) => {
         return new Promise((resolve, reject) => {
             base(params.tableName)
@@ -54,6 +82,7 @@ const airtable = module.exports = (function () {
 
     return {
         fetchBaseRecords,
+        fetchFilteredRecords,
         fetchTableRecord
     };
 


### PR DESCRIPTION
The GraphQL API now allows for a weeklySetblocks
property to be called on any TeamMember which will
query the Airtable API and get all Setblocks scheduled
for the current week from Sunday to Saturday, closes #16 

Sample query:
```
query {
  teamMemberById(id: "recGVSamjigJbZoJ8") {
    id,
    name,
    weeklySetblocks {
      id,
      date,
      blockTime,
      blockFraction,
      description
    }
  }
}
```